### PR TITLE
Fixed a warning regarding the length of the PO fitted values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 .RData
 .Ruserdata
 RISDM.Rproj
+RISDM.pdf
+RISDMbuildInfo.txt
 /doc/
 /Meta/
-RISDMbuildInfo.txt
+

--- a/R/isdm_onGrid.R
+++ b/R/isdm_onGrid.R
@@ -133,7 +133,7 @@ isdm <- function( observationList=list( POdat=NULL, PAdat=NULL, AAdat=NULL, DCda
 
   #the return object, which contains some of the bits and pieces calcuated above.
   res <- list( mod=mod, distributionFormula=distributionFormula, biasFormula=biasFormula, artefactFormulas=artefactFormulas, mesh=FullMesh$mesh, control=control, responseNames=responseNames, 
-		data=list( covars=newInfo$covarBrick, obsList=newInfo$obsList))
+		data=list( covars=newInfo$covarBrick, obsList=newInfo$obsList, habitatArea=habitatArea))
   #include the stack if requested
   if( control$returnStack){
     res$stack <- stck


### PR DESCRIPTION
Function plot.isdm() gives a warning message below 

![cbind_error](https://github.com/Scott-Foster/RISDM/assets/102031393/347db8f2-0acb-49d7-acc2-005592ce6039)

The inconsistency between the raster and the fitted PO values in length is because plot.isdm() did not account for the number of zero habit but MakePPPstack.R did.

The issue has been fixed [0042886a40600e986ca288e08cb8cc565e54d3d7]:

 * Function isdm outputs habitatArea.
 * Function plot.isdm uses habitatArea of the isdm output to identify the number of zero habit and treats them as NA.

A minor change:

 * Add RISDM.pdf in .gitignore because it is an empty and binary file. 
 