### PR TITLE
Estimate detection probabilities for double count data using the method of moments (MM)

### DIFF
--- a/R/DC_detProbMM.R
+++ b/R/DC_detProbMM.R
@@ -1,0 +1,44 @@
+
+###############################################################################################
+###############################################################################################
+####	
+####	Estimate detection probability using the method of moments when the observed data 
+####  ("obs1", "obs2", "both") follows a multinominal distribution with parameters 
+####  (N, p_1 x (1-p_2), (1-p_1) x p_2, p_1 x p_2).   
+####
+####	Return 
+####   * a vector of two probabilities when p_1 != p_2 
+####   * one probability when p_1 = p_2 
+####
+####	Programmed by Wen-Hsi (26/5/2025)
+####
+###############################################################################################
+###############################################################################################
+
+DC_detProbMM <- function( dat, is_p1_p2_same = TRUE){
+  #dat is an nx3 matrix with colnames c("obs1","obs2","both")
+  #data should already be ordered by the way that this function is called...
+  
+  if( sum( as.matrix( dat)) <= 0)
+    stop( "At least one of the DC surveys hasn't seen a single individual in any transect by either observer.\n There is no way that detection probabilities can be estiamted.\n Please reconsider model (e.g. add these points as SC as an off-the-cuff suggestion/hack).")
+
+  y1_mean <- mean(dat[,1])
+  y2_mean <- mean(dat[,2])
+  y3_mean <- mean(dat[,3])
+
+  if (is_p1_p2_same) {
+    # when p_1 = p_2
+    expans.pts <- (2*y3_mean)/(y1_mean + y2_mean + 2*y3_mean)
+  } else {
+    # when p_1 != p_2
+    expans.pts <- c(
+      # p_1 
+      y3_mean/(y2_mean + y3_mean),
+      # p_2 
+      y3_mean/(y1_mean + y3_mean)
+    )
+  }
+ 
+  return( expans.pts)
+}
+

--- a/R/prepareSingleSurvey.R
+++ b/R/prepareSingleSurvey.R
@@ -27,7 +27,8 @@ prepareSingleSurvey <- function( singleDataSet, datasetID, DCcols, survIDname, s
 #    stop( "At least one of the DC data sets has an observer that hasn't seen a single individual. This is currently outside of RISDM's scope. Sorry. Consider adjusting model.")
   
   #the bits and pieces for approximating log( 1-pi)
-  expansPis <- estimatePisDoubleCount( singleDataSet[,DCcols])
+  #expansPis <- estimatePisDoubleCount( singleDataSet[,DCcols])
+  expansPis <- DC_detProbMM( singleDataSet[,DCcols], is_p1_p2_same = TRUE) 
   singleDataSet$pi <- expansPis
 #  singleDataSet$Obs1_pi <- expansPis[1]
 #  singleDataSet$Obs2_pi <- expansPis[2]

--- a/tests/testthat/test_PopEstimate.R
+++ b/tests/testthat/test_PopEstimate.R
@@ -40,7 +40,7 @@ testthat::test_that(
     tmp <- PopEstimate( preds=fm$preds, control=list( probs=c(0.0025,0.4,0.6,0.9975)))
     testthat::expect_length( tmp, 6)
     
-    tmp <- PopEstimate( preds=fm$preds, intercept.terms = c( "DC_Intercept","DC_SurveyDCsurvey_3"))
+    tmp <- PopEstimate( preds=fm$preds, intercept.terms = c( "DC_Intercept","DC_logDetectPi"))
     testthat::expect_length( tmp, 6)
   }
 )


### PR DESCRIPTION
Added an R function (i.e. DC_detProbMM()) for estimating the DC detection probabilities using MM. The function can estimate probabilities for two cases: 
  * Observer 1 and Observer 2 have the same detection probability (default).
  * Observer 1 and Observer 2 have different detection probabilities (default).

This function is implemented in prepareSingleSurvey() to replace estimatePisDoubleCount().

On the other hand, fixed an error in test_PopEstimate.R by replacing "DC_SurveyDCsurvey_3" with "DC_logDetectPi".
